### PR TITLE
Update deprecated interaction response methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/pg": "^8.15.5",
         "nodemon": "^3.1.10",
         "tsx": "^4.19.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "@types/pg": "^8.15.5",
     "nodemon": "^3.1.10",
     "tsx": "^4.19.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/src/commands/moveall.ts
+++ b/src/commands/moveall.ts
@@ -94,7 +94,7 @@ const command: BotCommand = {
       return;
     }
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     const results = await Promise.allSettled(
       members.map((m) => m.voice.setChannel(target).then(() => m.user.tag))

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -4,7 +4,8 @@ import type { BotCommand } from '../types/command';
 const command: BotCommand = {
   data: new SlashCommandBuilder().setName('ping').setDescription('Check bot latency'),
   async execute(interaction) {
-    const sent = await interaction.reply({ content: 'Pinging...', fetchReply: true });
+    await interaction.reply({ content: 'Pinging...' });
+    const sent = await interaction.fetchReply();
     const latency = sent.createdTimestamp - interaction.createdTimestamp;
     await interaction.editReply(`Pong! Latency: ${latency}ms`);
   },

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -30,7 +30,7 @@ const command: BotCommand = {
       await interaction.reply({ content: 'This command can only be used in text channels.', flags: MessageFlags.Ephemeral });
       return;
     }
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     const deleted = await channel.bulkDelete(amount, true).catch(() => null);
     if (!deleted) {
       await interaction.editReply('Failed to delete messages. I can only delete messages newer than 14 days and need proper permissions.');

--- a/src/commands/trivia.ts
+++ b/src/commands/trivia.ts
@@ -22,7 +22,8 @@ const command: BotCommand = {
 
     const questionText = `🧠 ${trivia.q}\n${trivia.options.map((o, i) => `${letters[i]}. ${o}`).join('\n')}\n\nChoose the correct answer:`;
 
-    const sent = await interaction.reply({ content: questionText, components: [row], fetchReply: true });
+    await interaction.reply({ content: questionText, components: [row] });
+    const sent = await interaction.fetchReply();
 
     try {
       const btn = await sent.awaitMessageComponent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { Client, Events, GatewayIntentBits, Partials, ActivityType } from 'discord.js';
+import { Client, Events, GatewayIntentBits, Partials, ActivityType, MessageFlags } from 'discord.js';
 import { registerDmAiHandler } from './handlers/dm';
 import fs from 'fs';
 import path from 'path';
@@ -55,7 +55,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
     if (interaction.deferred || interaction.replied) {
       await interaction.editReply({ content: `Error: ${message}` }).catch(() => {});
     } else {
-      await interaction.reply({ content: `Error: ${message}`, ephemeral: true }).catch(() => {});
+      await interaction.reply({ content: `Error: ${message}`, flags: MessageFlags.Ephemeral }).catch(() => {});
     }
   }
 });


### PR DESCRIPTION
Replace deprecated `fetchReply` and `ephemeral` interaction response options with `fetchReply()` and `flags: MessageFlags.Ephemeral` to resolve deprecation warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-a65cbb46-ae6d-4170-afc1-b8406a4f7587">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a65cbb46-ae6d-4170-afc1-b8406a4f7587">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

