### PR TITLE
Implement AI request cooldown and queue

### DIFF
--- a/src/handlers/dm.ts
+++ b/src/handlers/dm.ts
@@ -19,6 +19,50 @@ export function registerDmAiHandler(client: Client) {
   const perChannelMemory = new Map<string, GeminiHistoryItem[]>();
   const BARRIERS = new Set(['!stop', '!clear', '!reset', '!forget']);
 
+  // Global cooldown and request queue to respect Gemini free tier 10 RPM (~6s)
+  const COOLDOWN_MS = 6000;
+  type QueueTask = () => Promise<void>;
+  const requestQueue: QueueTask[] = [];
+  let isProcessingQueue = false;
+  let lastRequestTimestamp = 0;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async function waitForCooldown(): Promise<void> {
+    const now = Date.now();
+    const waitMs = Math.max(0, lastRequestTimestamp + COOLDOWN_MS - now);
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+    lastRequestTimestamp = Date.now();
+  }
+
+  function enqueueRequest(task: QueueTask): void {
+    requestQueue.push(task);
+    if (!isProcessingQueue) {
+      void processQueue();
+    }
+  }
+
+  async function processQueue(): Promise<void> {
+    if (isProcessingQueue) return;
+    isProcessingQueue = true;
+    try {
+      while (requestQueue.length > 0) {
+        const task = requestQueue.shift()!;
+        try {
+          await task();
+        } catch {
+          // Individual task handles its own errors for user feedback
+        }
+      }
+    } finally {
+      isProcessingQueue = false;
+    }
+  }
+
   client.on(Events.MessageCreate, async (message: Message) => {
     if (message.author.bot) return;
     if (message.guild) return; // only DMs
@@ -50,84 +94,97 @@ export function registerDmAiHandler(client: Client) {
       return;
     }
 
-    try {
-      const model = genai.getGenerativeModel({
-        model: 'gemini-2.5-flash',
-        systemInstruction:
-          `You are a helpful Discord bot called Tasky. Be concise and friendly. Use Discord compatible markdown. The current user's username is "${message.author.username}" If the user asks about server-specific actions, remind them you can only chat in DMs.`
-      });
+    enqueueRequest(async () => {
+      try {
+        // Enforce cooldown just before making the API call
+        await waitForCooldown();
 
-      // Build history from Postgres if configured; fallback to in-memory
-      let history: GeminiHistoryItem[] = [];
-      if (isDbEnabled) {
-        const stored = await fetchChannelMessages(message.channel.id, MAX_MESSAGES);
-        const storedAsc = stored
-          .filter(r => typeof r.content === 'string' && r.content.trim().length > 0)
-          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-        history = storedAsc.map(r => ({ role: r.role, parts: [{ text: r.content.trim() }] }));
-      }
-      if (!isDbEnabled || history.length === 0) {
-        const mem = perChannelMemory.get(message.channel.id);
-        if (mem && mem.length > 0) {
-          history = mem.slice(-2 * MAX_MEMORY_TURNS);
+        const model = genai.getGenerativeModel({
+          model: 'gemini-2.5-flash',
+          systemInstruction:
+            `You are a helpful Discord bot called Tasky. Be concise and friendly. Use Discord compatible markdown. The current user's username is "${message.author.username}" If the user asks about server-specific actions, remind them you can only chat in DMs.`
+        });
+
+        // Build history from Postgres if configured; fallback to in-memory
+        let history: GeminiHistoryItem[] = [];
+        if (isDbEnabled) {
+          const stored = await fetchChannelMessages(message.channel.id, MAX_MESSAGES);
+          const storedAsc = stored
+            .filter(r => typeof r.content === 'string' && r.content.trim().length > 0)
+            .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+          history = storedAsc.map(r => ({ role: r.role, parts: [{ text: r.content.trim() }] }));
         }
-      }
-
-      const chat = model.startChat({ history });
-      const result = await chat.sendMessage(message.content);
-      const response = result.response?.text?.() ?? null;
-
-      if (!response || response.trim().length === 0) {
-        await message.author.send('Sorry, I could not generate a response.');
-        return;
-      }
-
-      // Discord embed description limit is 4096 characters.
-      // We'll slice the response into 4096-char chunks and send as multiple embeds if necessary.
-      const EMBED_DESC_MAX = 4096;
-      const chunks: string[] = [];
-      let remaining = response;
-      while (remaining.length > EMBED_DESC_MAX) {
-        chunks.push(remaining.slice(0, EMBED_DESC_MAX));
-        remaining = remaining.slice(EMBED_DESC_MAX);
-      }
-      chunks.push(remaining);
-
-      for (let i = 0; i < chunks.length; i++) {
-        const chunk = chunks[i];
-        const embed = new EmbedBuilder()
-          .setDescription(chunk)
-          .setColor(0x5865F2)
-          .setAuthor({
-            name: 'Gemini 2.5 Flash',
-            url: 'https://deepmind.google/models/gemini/',
-            iconURL: 'https://uxwing.com/wp-content/themes/uxwing/download/brands-and-social-media/google-gemini-icon.png',
-          });
-        if (chunks.length > 1) {
-          embed.setFooter({ text: `Part ${i + 1} / ${chunks.length}` });
+        if (!isDbEnabled || history.length === 0) {
+          const mem = perChannelMemory.get(message.channel.id);
+          if (mem && mem.length > 0) {
+            history = mem.slice(-2 * MAX_MEMORY_TURNS);
+          }
         }
-        await message.author.send({ embeds: [embed] });
-      }
 
-      // Persist to DB when available; otherwise update in-memory fallback
-      if (isDbEnabled) {
-        try {
-          await insertMessage({
-            userId: message.author.id,
-            channelId: message.channel.id,
-            role: 'user',
-            content: message.content,
-            timestamp: new Date(message.createdTimestamp)
-          });
-          await insertMessage({
-            userId: message.client.user?.id ?? 'bot',
-            channelId: message.channel.id,
-            role: 'model',
-            content: response,
-            timestamp: new Date()
-          });
-        } catch {
-          // If DB insert fails, still maintain in-memory fallback
+        const chat = model.startChat({ history });
+        const result = await chat.sendMessage(message.content);
+        const response = result.response?.text?.() ?? null;
+
+        if (!response || response.trim().length === 0) {
+          await message.author.send('Sorry, I could not generate a response.');
+          return;
+        }
+
+        // Discord embed description limit is 4096 characters.
+        // We'll slice the response into 4096-char chunks and send as multiple embeds if necessary.
+        const EMBED_DESC_MAX = 4096;
+        const chunks: string[] = [];
+        let remaining = response;
+        while (remaining.length > EMBED_DESC_MAX) {
+          chunks.push(remaining.slice(0, EMBED_DESC_MAX));
+          remaining = remaining.slice(EMBED_DESC_MAX);
+        }
+        chunks.push(remaining);
+
+        for (let i = 0; i < chunks.length; i++) {
+          const chunk = chunks[i];
+          const embed = new EmbedBuilder()
+            .setDescription(chunk)
+            .setColor(0x5865F2)
+            .setAuthor({
+              name: 'Gemini 2.5 Flash',
+              url: 'https://deepmind.google/models/gemini/',
+              iconURL: 'https://uxwing.com/wp-content/themes/uxwing/download/brands-and-social-media/google-gemini-icon.png',
+            });
+          if (chunks.length > 1) {
+            embed.setFooter({ text: `Part ${i + 1} / ${chunks.length}` });
+          }
+          await message.author.send({ embeds: [embed] });
+        }
+
+        // Persist to DB when available; otherwise update in-memory fallback
+        if (isDbEnabled) {
+          try {
+            await insertMessage({
+              userId: message.author.id,
+              channelId: message.channel.id,
+              role: 'user',
+              content: message.content,
+              timestamp: new Date(message.createdTimestamp)
+            });
+            await insertMessage({
+              userId: message.client.user?.id ?? 'bot',
+              channelId: message.channel.id,
+              role: 'model',
+              content: response,
+              timestamp: new Date()
+            });
+          } catch {
+            // If DB insert fails, still maintain in-memory fallback
+            const mem = perChannelMemory.get(message.channel.id) ?? [];
+            mem.push({ role: 'user', parts: [{ text: message.content }] });
+            mem.push({ role: 'model', parts: [{ text: response }] });
+            perChannelMemory.set(
+              message.channel.id,
+              mem.length > 2 * MAX_MEMORY_TURNS ? mem.slice(-2 * MAX_MEMORY_TURNS) : mem
+            );
+          }
+        } else {
           const mem = perChannelMemory.get(message.channel.id) ?? [];
           mem.push({ role: 'user', parts: [{ text: message.content }] });
           mem.push({ role: 'model', parts: [{ text: response }] });
@@ -136,19 +193,11 @@ export function registerDmAiHandler(client: Client) {
             mem.length > 2 * MAX_MEMORY_TURNS ? mem.slice(-2 * MAX_MEMORY_TURNS) : mem
           );
         }
-      } else {
-        const mem = perChannelMemory.get(message.channel.id) ?? [];
-        mem.push({ role: 'user', parts: [{ text: message.content }] });
-        mem.push({ role: 'model', parts: [{ text: response }] });
-        perChannelMemory.set(
-          message.channel.id,
-          mem.length > 2 * MAX_MEMORY_TURNS ? mem.slice(-2 * MAX_MEMORY_TURNS) : mem
-        );
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        await message.author.send(`Error generating AI response: ${errMsg}`);
       }
-    } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      await message.author.send(`Error generating AI response: ${errMsg}`);
-    }
+    });
   });
 }
 


### PR DESCRIPTION
Add a 6-second cooldown and request queue for AI DM responses to comply with Gemini 2.5 Flash free tier rate limits.

Incoming AI requests are now enqueued, and the system ensures at least 6 seconds pass between calls to the Gemini API. Requests made during a cooldown period are buffered and processed sequentially once the cooldown elapses.

---
<a href="https://cursor.com/background-agent?bcId=bc-f417f957-ca92-4319-8f9a-738eae4df0e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f417f957-ca92-4319-8f9a-738eae4df0e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

